### PR TITLE
Add berlin tests with actual berlin and bump

### DIFF
--- a/app/views/berlin.py
+++ b/app/views/berlin.py
@@ -41,7 +41,7 @@ def berlin_search():
     lev_distance = request.args.get("lev_distance", 2, type=int)
 
     try:
-        result = db.query(q, state, limit or 10, lev_distance or 2)
+        result = db.query(q, state=state, limit=limit or 10, lev_distance=lev_distance or 2)
         locations = {
             "matches": [
                 {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "Flask>=2.0.2<2.1",
     "structlog>=21.5.0,<21.6",
     "python-dateutil>=2.8.2,<2.9",
-    "berlin>=0.3.0,<4",
+    "berlin>=0.3.7,<4",
 ]
 
 [project.optional-dependencies]

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 import json
 from unittest.mock import patch
-import app.store
 
 import pytest
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,10 +1,47 @@
 from dataclasses import dataclass
+import json
 from unittest.mock import patch
+import app.store
 
 import pytest
 
-from api import create_app
+def load_test_code_list():
+    return [{
+        "change": "",
+        "country": "BG",
+        "subcode": "BLO",
+        "name": "Lyuliakovo",
+        "name_wo_diacritics": "Lyuliakovo",
+        "subdivision_code": "02",
+        "status": "RL",
+        "function": "-----6--",
+        "date": "0901",
+        "iata_code": "",
+        "coordinates": "4283N 02701E",
+    }]
 
+def load_test_codes():
+    return [json.dumps({
+        "BG": {
+            "<c>": "ISO-3166-1",
+            "s": "<bln|ISO-3166-1#BG|\"Bulgaria\">",
+            "i": "BG",
+            "d": {
+                "name": "Bulgaria",
+                "short": "Bulgaria",
+                "alpha2": "BG",
+                "alpha3": "BGR",
+                "official_en": "Bulgaria",
+                "official_fr": "Bulgarie",
+                "continent": "EU"
+            }
+        }
+    })]
+
+
+def real_berlin_load(location):
+    import berlin
+    return berlin.load_from_json([load_test_codes()], load_test_code_list())
 
 def fake_berlin_load(location):
     @dataclass
@@ -23,8 +60,24 @@ def fake_berlin_load(location):
 
 
 @pytest.fixture()
+def app_with_berlin():
+    with patch("app.store.load", real_berlin_load):
+        from api import create_app
+
+        app = create_app()
+        app.config.update(
+            {
+                "TESTING": True,
+            }
+        )
+
+        yield app
+
+@pytest.fixture()
 def app():
     with patch("app.store.load", fake_berlin_load):
+        from api import create_app
+
         app = create_app()
         app.config.update(
             {
@@ -36,8 +89,12 @@ def app():
 
 
 @pytest.fixture()
+def test_client_with_berlin(app_with_berlin):
+    yield app_with_berlin.test_client()
+
+@pytest.fixture()
 def test_client(app):
-    return app.test_client()
+    yield app.test_client()
 
 
 @pytest.fixture()

--- a/tests/api/server_test.py
+++ b/tests/api/server_test.py
@@ -4,6 +4,11 @@ def test_health_check(test_client):
     assert '"OK"' in response.text
 
 
+def test_search_with_state_with_berlin(test_client_with_berlin):
+    response = test_client_with_berlin.get("/berlin/search?q=Manch&state=GB&limit=2")
+    assert response.status_code == 200
+    assert isinstance(response.json, dict)
+
 def test_search_with_state(test_client):
     response = test_client.get("/berlin/search?q=Manch&state=GB&limit=2")
     assert response.status_code == 200


### PR DESCRIPTION
This uses actual berlin (optionally) to run tests and allows programmatic loading of fake data to do so.

This involves bumping the berlin-py dependency.